### PR TITLE
Add EUR/SEK toggle and interactive loan panel widgets

### DIFF
--- a/src/MortgageCalculator.vue
+++ b/src/MortgageCalculator.vue
@@ -17,14 +17,17 @@
     
     <div class="calculator-grid">
       <LoanInputs 
-        :values="values" 
-        @update="updateValues" 
+        :values="values"
+        :currency="currency"
+        @update="updateValues"
+        @update:currency="setCurrency"
       />
       
       <ResultsDisplay 
         v-if="results"
         :results="results" 
         :values="values"
+        :currency="currency"
         @save="saveCurrentCalculation"
       />
     </div>
@@ -119,6 +122,7 @@
 
 <script>
 import { formatCurrency } from './utils/formatters';
+import { CURRENCIES } from './utils/currency';
 import { calculateMortgage } from './calculations/mortgageCalculator';
 import { saveCalculatorValues, loadCalculatorValues, saveCalculation, deleteCalculation, updateCalculation } from './services/storageServices';
 import { exportCalculation as exportCalc, parseImportedCalculation } from './services/exportService';
@@ -149,6 +153,7 @@ export default {
         loanTermYears: 30,
         brfFee: 3500
       },
+      currency: CURRENCIES.SEK,
       results: null,
       activeTab: 'scenarios',
       tabs: [
@@ -164,9 +169,10 @@ export default {
     };
   },
   created() {
-    const savedValues = loadCalculatorValues();
-    if (savedValues) {
-      this.values = savedValues;
+    const saved = loadCalculatorValues();
+    if (saved) {
+      this.values = saved.values;
+      this.currency = saved.currency || CURRENCIES.SEK;
     }
     this.calculateResults();
   },
@@ -174,8 +180,12 @@ export default {
     formatCurrency,
     updateValues(newValues) {
       this.values = newValues;
-      saveCalculatorValues(this.values);
+      saveCalculatorValues(this.values, this.currency);
       this.calculateResults();
+    },
+    setCurrency(newCurrency) {
+      this.currency = newCurrency;
+      saveCalculatorValues(this.values, this.currency);
     },
     calculateResults() {
       if (!this.values.currentLoanAmount || !this.values.propertyValue) return;
@@ -217,7 +227,7 @@ export default {
         brfFee: calculation.brfFee || 0
       };
       
-      saveCalculatorValues(this.values);
+      saveCalculatorValues(this.values, this.currency);
       this.calculateResults();
     },
     renameCalculation(calculation) {

--- a/src/calculations/mortgageCalculator.js
+++ b/src/calculations/mortgageCalculator.js
@@ -1,4 +1,5 @@
 // src/calculations/mortgageCalculator.js
+// Core Swedish mortgage calculation: LTV amortization, DTI surcharge, stress test.
 import { AMORTIZATION_RULES, DEBT_TO_INCOME_LIMIT, STRESS_TEST_RATE_INCREASE, MIN_INTEREST_RATE } from '../utils/constants';
 import { calculateAmortizationSchedule } from './amortizationSchedule';
 

--- a/src/components/CurrencyToggle.vue
+++ b/src/components/CurrencyToggle.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="currency-toggle segmented-control">
+    <button
+      v-for="option in options"
+      :key="option"
+      :class="{ active: modelValue === option }"
+      @click="$emit('update:modelValue', option)"
+    >
+      {{ option }}
+    </button>
+  </div>
+</template>
+
+<script>
+import { CURRENCIES } from '../utils/currency.js';
+
+export default {
+  name: 'CurrencyToggle',
+  props: {
+    modelValue: {
+      type: String,
+      default: CURRENCIES.SEK,
+    },
+  },
+  emits: ['update:modelValue'],
+  data() {
+    return {
+      options: [CURRENCIES.SEK, CURRENCIES.EUR],
+    };
+  },
+};
+</script>

--- a/src/components/LoanInputs.vue
+++ b/src/components/LoanInputs.vue
@@ -1,140 +1,170 @@
-<!-- src/components/LoanInputs.vue -->
 <template>
-    <div class="loan-inputs card">
+  <div class="loan-inputs card">
+    <div class="card-header">
       <h2 class="card-title">Loan Details</h2>
-      <div class="form-grid">
-        <div class="form-group">
-          <label for="originalLoanAmount">Original Loan Amount (SEK)</label>
-          <input 
-            type="number" 
-            id="originalLoanAmount" 
-            v-model.number="localValues.originalLoanAmount"
-            @input="handleOriginalLoanChange"
-          >
-          <div class="tooltip-hint">Initial loan amount when you took the mortgage</div>
-        </div>
-        
-        <div class="form-group">
-          <label for="currentLoanAmount">Current Loan Amount (SEK)</label>
-          <input 
-            type="number" 
-            id="currentLoanAmount" 
-            v-model.number="localValues.currentLoanAmount"
-            @input="handleCurrentLoanChange"
-          >
-          <div class="tooltip-hint">Your current remaining loan</div>
-        </div>
-        
-        <div class="form-group">
-          <label for="propertyValue">Property Value (SEK)</label>
-          <input 
-            type="number" 
-            id="propertyValue" 
-            v-model.number="localValues.propertyValue"
-            @input="emitUpdate"
-          >
-        </div>
-        
-        <div class="form-group">
-          <label for="annualIncome">Annual Income (SEK)</label>
-          <input 
-            type="number" 
-            id="annualIncome" 
-            v-model.number="localValues.annualIncome"
-            @input="emitUpdate"
-          >
-        </div>
-        
-        <div class="form-group">
-          <label for="interestRate">Interest Rate (%)</label>
-          <input 
-            type="number" 
-            id="interestRate" 
-            v-model.number="localValues.interestRate"
-            step="0.01"
-            @input="emitUpdate"
-          >
-        </div>
-        
-        <div class="form-group">
-          <label for="loanTermYears">Loan Term (Years)</label>
-          <input 
-            type="number" 
-            id="loanTermYears" 
-            v-model.number="localValues.loanTermYears"
-            @input="emitUpdate"
-          >
-        </div>
-        
-        <div class="form-group">
-          <label for="brfFee">Brf Fee (SEK/month)</label>
-          <input 
-            type="number" 
-            id="brfFee" 
-            v-model.number="localValues.brfFee"
-            @input="emitUpdate"
-          >
-        </div>
+      <CurrencyToggle :model-value="currency" @update:model-value="$emit('update:currency', $event)" />
+    </div>
+
+    <p v-if="currency === CURRENCIES.EUR" class="currency-note">
+      Amounts shown in EUR (stored in SEK at 1 EUR = {{ EUR_SEK_RATE }} SEK)
+    </p>
+
+    <div class="input-section">
+      <h3 class="section-header">Loan amounts</h3>
+      <div class="input-grid">
+        <MoneyInput
+          :model-value="localValues.originalLoanAmount"
+          label="Original Loan Amount"
+          :min="0"
+          :max="10000000"
+          :step="50000"
+          :currency="currency"
+          hint="Initial loan amount when you took the mortgage"
+          @update:model-value="updateField('originalLoanAmount', $event, true)"
+        />
+        <MoneyInput
+          :model-value="localValues.currentLoanAmount"
+          label="Current Loan Amount"
+          :min="0"
+          :max="localValues.originalLoanAmount"
+          :step="50000"
+          :currency="currency"
+          hint="Your current remaining loan"
+          @update:model-value="updateField('currentLoanAmount', $event, true)"
+        />
       </div>
     </div>
-  </template>
-  
-  <script>
-  export default {
-    name: 'LoanInputs',
-    props: {
-      values: {
-        type: Object,
-        required: true
-      }
+
+    <div class="input-section">
+      <h3 class="section-header">Property &amp; income</h3>
+      <div class="input-grid">
+        <MoneyInput
+          :model-value="localValues.propertyValue"
+          label="Property Value"
+          :min="0"
+          :max="20000000"
+          :step="50000"
+          :currency="currency"
+          @update:model-value="updateField('propertyValue', $event)"
+        />
+        <MoneyInput
+          :model-value="localValues.annualIncome"
+          label="Annual Income"
+          :min="0"
+          :max="5000000"
+          :step="10000"
+          :currency="currency"
+          @update:model-value="updateField('annualIncome', $event)"
+        />
+      </div>
+    </div>
+
+    <div class="input-section">
+      <h3 class="section-header">Terms &amp; fees</h3>
+      <div class="input-grid">
+        <SliderInput
+          :model-value="localValues.interestRate"
+          label="Interest Rate"
+          :min="0.1"
+          :max="15"
+          :step="0.01"
+          unit="%"
+          @update:model-value="updateField('interestRate', $event)"
+        />
+        <SliderInput
+          :model-value="localValues.loanTermYears"
+          label="Loan Term"
+          :min="1"
+          :max="40"
+          :step="1"
+          unit="years"
+          @update:model-value="updateField('loanTermYears', $event)"
+        />
+        <MoneyInput
+          :model-value="localValues.brfFee"
+          label="Brf Fee"
+          :min="0"
+          :max="20000"
+          :step="100"
+          :currency="currency"
+          hint="Monthly housing association fee"
+          @update:model-value="updateField('brfFee', $event)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import CurrencyToggle from './CurrencyToggle.vue';
+import MoneyInput from './MoneyInput.vue';
+import SliderInput from './SliderInput.vue';
+import { CURRENCIES, EUR_SEK_RATE } from '../utils/currency.js';
+
+export default {
+  name: 'LoanInputs',
+  components: {
+    CurrencyToggle,
+    MoneyInput,
+    SliderInput,
+  },
+  props: {
+    values: {
+      type: Object,
+      required: true,
     },
-    data() {
-      return {
-        localValues: { ...this.values }
-      };
+    currency: {
+      type: String,
+      default: CURRENCIES.SEK,
     },
-    watch: {
-      values: {
-        handler(newValues) {
-          this.localValues = { ...newValues };
-        },
-        deep: true
-      }
-    },
-    methods: {
-      handleOriginalLoanChange() {
-        // Ensure current loan doesn't exceed original loan
-        if (this.localValues.currentLoanAmount > this.localValues.originalLoanAmount) {
-          this.localValues.currentLoanAmount = this.localValues.originalLoanAmount;
-        }
-        this.emitUpdate();
+  },
+  emits: ['update', 'update:currency'],
+  data() {
+    return {
+      localValues: { ...this.values },
+      CURRENCIES,
+      EUR_SEK_RATE,
+    };
+  },
+  watch: {
+    values: {
+      handler(newValues) {
+        this.localValues = { ...newValues };
       },
-      handleCurrentLoanChange() {
-        // Ensure current loan doesn't exceed original loan
-        if (this.localValues.currentLoanAmount > this.localValues.originalLoanAmount) {
-          this.localValues.currentLoanAmount = this.localValues.originalLoanAmount;
-        }
-        this.emitUpdate();
-      },
-      emitUpdate() {
-        this.$emit('update', { ...this.localValues });
+      deep: true,
+    },
+  },
+  methods: {
+    updateField(field, value, validateLoan = false) {
+      this.localValues[field] = value;
+
+      if (validateLoan && this.localValues.currentLoanAmount > this.localValues.originalLoanAmount) {
+        this.localValues.currentLoanAmount = this.localValues.originalLoanAmount;
       }
-    }
-  };
-  </script>
-  
-  <style scoped>
-  .loan-inputs {
-    padding: 1.5rem;
-  }
-  
-  .form-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: 1.125rem;
-  }
-  
-  .form-group {
-    margin-bottom: 0;
-  }
-  </style>
+
+      this.emitUpdate();
+    },
+    emitUpdate() {
+      this.$emit('update', { ...this.localValues });
+    },
+  },
+};
+</script>
+
+<style scoped>
+.loan-inputs {
+  padding: 1.5rem;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.25rem;
+}
+
+.card-header .card-title {
+  margin-bottom: 0;
+}
+</style>

--- a/src/components/MoneyInput.vue
+++ b/src/components/MoneyInput.vue
@@ -1,0 +1,72 @@
+<template>
+  <SliderInput
+    :model-value="displayValue"
+    :label="label"
+    :min="displayMin"
+    :max="displayMax"
+    :step="displayStep"
+    :unit="currency"
+    :hint="hint"
+    @update:model-value="handleUpdate"
+  />
+</template>
+
+<script>
+import SliderInput from './SliderInput.vue';
+import { toDisplayAmount, fromDisplayAmount } from '../utils/currency.js';
+
+export default {
+  name: 'MoneyInput',
+  components: { SliderInput },
+  props: {
+    modelValue: {
+      type: Number,
+      required: true,
+    },
+    label: {
+      type: String,
+      required: true,
+    },
+    min: {
+      type: Number,
+      default: 0,
+    },
+    max: {
+      type: Number,
+      required: true,
+    },
+    step: {
+      type: Number,
+      default: 10000,
+    },
+    currency: {
+      type: String,
+      required: true,
+    },
+    hint: {
+      type: String,
+      default: '',
+    },
+  },
+  emits: ['update:modelValue'],
+  computed: {
+    displayValue() {
+      return toDisplayAmount(this.modelValue, this.currency);
+    },
+    displayMin() {
+      return toDisplayAmount(this.min, this.currency);
+    },
+    displayMax() {
+      return toDisplayAmount(this.max, this.currency);
+    },
+    displayStep() {
+      return Math.max(1, toDisplayAmount(this.step, this.currency));
+    },
+  },
+  methods: {
+    handleUpdate(displayAmount) {
+      this.$emit('update:modelValue', fromDisplayAmount(displayAmount, this.currency));
+    },
+  },
+};
+</script>

--- a/src/components/ResultsDisplay.vue
+++ b/src/components/ResultsDisplay.vue
@@ -4,27 +4,42 @@
 
     <div class="payment-hero">
       <span class="hero-label">Total with Brf Fee</span>
-      <span class="hero-value">{{ formatCurrency(totalWithBrf) }} <small>SEK</small></span>
-      <span class="hero-sub">Mortgage {{ formatCurrency(results.totalMonthlyPayment) }} + Brf {{ formatCurrency(values.brfFee) }}</span>
+      <span class="hero-value">
+        {{ formatCurrency(displayTotalWithBrf) }}
+        <small>{{ currency }}</small>
+      </span>
+      <span class="hero-sub">
+        Mortgage {{ formatCurrency(displayMonthlyPayment) }} + Brf {{ formatCurrency(displayBrfFee) }}
+      </span>
     </div>
 
-    <div class="result-list">
-      <div class="result-item">
-        <span class="result-label">Monthly Amortization</span>
-        <span class="result-value">{{ formatCurrency(results.monthlyAmortization) }} SEK</span>
+    <div class="stat-grid">
+      <div class="stat-card stat-card--success">
+        <span class="stat-card-label">Monthly Amortization</span>
+        <span class="stat-card-value">
+          {{ formatCurrency(displayAmortization) }}
+          <small>{{ currency }}</small>
+        </span>
       </div>
-      <div class="result-item">
-        <span class="result-label">Monthly Interest</span>
-        <span class="result-value">{{ formatCurrency(results.monthlyInterest) }} SEK</span>
+      <div class="stat-card stat-card--warning">
+        <span class="stat-card-label">Monthly Interest</span>
+        <span class="stat-card-value">
+          {{ formatCurrency(displayInterest) }}
+          <small>{{ currency }}</small>
+        </span>
       </div>
-      <div class="result-item">
-        <span class="result-label">Total Monthly Payment</span>
-        <span class="result-value">{{ formatCurrency(results.totalMonthlyPayment) }} SEK</span>
+      <div class="stat-card stat-card--primary">
+        <span class="stat-card-label">Total Monthly Payment</span>
+        <span class="stat-card-value">
+          {{ formatCurrency(displayMonthlyPayment) }}
+          <small>{{ currency }}</small>
+        </span>
       </div>
-      <div class="result-item accent">
-        <span class="result-label">Required Amortization Rate</span>
-        <span class="result-value">{{ results.amortizationRate.toFixed(1) }}%</span>
-      </div>
+    </div>
+
+    <div class="result-item accent">
+      <span class="result-label">Required Amortization Rate</span>
+      <span class="result-value">{{ results.amortizationRate.toFixed(1) }}%</span>
     </div>
 
     <button @click="saveCalculation" class="save-btn btn-primary">
@@ -35,30 +50,49 @@
 
 <script>
 import { formatCurrency } from '../utils/formatters';
+import { toDisplayAmount, CURRENCIES } from '../utils/currency.js';
 
 export default {
   name: 'ResultsDisplay',
   props: {
     results: {
       type: Object,
-      required: true
+      required: true,
     },
     values: {
       type: Object,
-      required: true
-    }
+      required: true,
+    },
+    currency: {
+      type: String,
+      default: CURRENCIES.SEK,
+    },
   },
   computed: {
-    totalWithBrf() {
-      return this.results.totalMonthlyPayment + this.values.brfFee;
-    }
+    displayMonthlyPayment() {
+      return toDisplayAmount(this.results.totalMonthlyPayment, this.currency);
+    },
+    displayAmortization() {
+      return toDisplayAmount(this.results.monthlyAmortization, this.currency);
+    },
+    displayInterest() {
+      return toDisplayAmount(this.results.monthlyInterest, this.currency);
+    },
+    displayBrfFee() {
+      return toDisplayAmount(this.values.brfFee, this.currency);
+    },
+    displayTotalWithBrf() {
+      return this.displayMonthlyPayment + this.displayBrfFee;
+    },
   },
   methods: {
-    formatCurrency,
+    formatCurrency(amount) {
+      return formatCurrency(amount, this.currency);
+    },
     saveCalculation() {
       this.$emit('save');
-    }
-  }
+    },
+  },
 };
 </script>
 
@@ -68,11 +102,25 @@ export default {
 }
 
 .payment-hero {
-  background: linear-gradient(135deg, var(--color-primary-soft) 0%, rgba(6, 182, 212, 0.08) 100%);
-  border: 1px solid rgba(79, 70, 229, 0.15);
+  background: linear-gradient(135deg, #312e81 0%, #4f46e5 45%, #6366f1 100%);
+  border: none;
   border-radius: var(--radius-md);
-  padding: 1.25rem 1.5rem;
+  padding: 1.5rem;
   margin-bottom: 1.25rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.payment-hero::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  right: -20%;
+  width: 200px;
+  height: 200px;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.1) 0%, transparent 70%);
+  border-radius: 50%;
+  pointer-events: none;
 }
 
 .hero-label {
@@ -81,49 +129,44 @@ export default {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--color-primary);
+  color: rgba(255, 255, 255, 0.75);
   margin-bottom: 0.375rem;
+  position: relative;
 }
 
 .hero-value {
   display: block;
-  font-size: 2rem;
+  font-size: 2.25rem;
   font-weight: 700;
   letter-spacing: -0.03em;
-  color: var(--color-text);
+  color: white;
   line-height: 1.1;
+  position: relative;
 }
 
 .hero-value small {
   font-size: 1rem;
   font-weight: 500;
-  color: var(--color-text-muted);
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .hero-sub {
   display: block;
   margin-top: 0.5rem;
   font-size: 0.8125rem;
-  color: var(--color-text-muted);
-}
-
-.result-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
+  color: rgba(255, 255, 255, 0.65);
+  position: relative;
 }
 
 .result-item {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.625rem 0;
-  border-bottom: 1px solid var(--color-border);
+  padding: 0.875rem 1rem;
+  background: var(--color-surface-muted);
+  border-radius: var(--radius-sm);
   font-size: 0.875rem;
-}
-
-.result-item:last-child {
-  border-bottom: none;
+  margin-bottom: 1.25rem;
 }
 
 .result-item.accent .result-value {
@@ -141,7 +184,6 @@ export default {
 }
 
 .save-btn {
-  margin-top: 1.25rem;
   width: 100%;
 }
 </style>

--- a/src/components/SliderInput.vue
+++ b/src/components/SliderInput.vue
@@ -1,0 +1,146 @@
+<template>
+  <div class="input-widget">
+    <div class="input-widget-header">
+      <label :for="inputId">{{ label }}</label>
+      <span v-if="unit" class="unit-badge">{{ unit }}</span>
+    </div>
+    <input
+      type="range"
+      class="range-input"
+      :id="`${inputId}-range`"
+      :min="min"
+      :max="max"
+      :step="step"
+      :value="modelValue"
+      @input="handleRangeInput"
+    >
+    <div class="input-with-unit">
+      <input
+        type="number"
+        class="number-input"
+        :id="inputId"
+        :min="min"
+        :max="max"
+        :step="step"
+        :value="modelValue"
+        @input="handleNumberInput"
+      >
+      <span v-if="unit" class="input-unit">{{ unit }}</span>
+    </div>
+    <div v-if="hint" class="tooltip-hint">{{ hint }}</div>
+  </div>
+</template>
+
+<script>
+let sliderIdCounter = 0;
+
+export default {
+  name: 'SliderInput',
+  props: {
+    modelValue: {
+      type: Number,
+      required: true,
+    },
+    label: {
+      type: String,
+      required: true,
+    },
+    min: {
+      type: Number,
+      default: 0,
+    },
+    max: {
+      type: Number,
+      required: true,
+    },
+    step: {
+      type: Number,
+      default: 1,
+    },
+    unit: {
+      type: String,
+      default: '',
+    },
+    hint: {
+      type: String,
+      default: '',
+    },
+  },
+  emits: ['update:modelValue'],
+  data() {
+    return {
+      inputId: `slider-input-${++sliderIdCounter}`,
+    };
+  },
+  methods: {
+    clamp(value) {
+      return Math.min(this.max, Math.max(this.min, value));
+    },
+    handleRangeInput(event) {
+      this.$emit('update:modelValue', Number(event.target.value));
+    },
+    handleNumberInput(event) {
+      const value = Number(event.target.value);
+      if (Number.isNaN(value)) return;
+      this.$emit('update:modelValue', this.clamp(value));
+    },
+  },
+};
+</script>
+
+<style scoped>
+.input-widget {
+  padding: 1rem;
+  background: linear-gradient(135deg, var(--color-primary-soft) 0%, rgba(6, 182, 212, 0.05) 100%);
+  border: 1px solid rgba(79, 70, 229, 0.12);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.input-widget:hover {
+  border-color: rgba(79, 70, 229, 0.25);
+  box-shadow: 0 2px 12px rgba(79, 70, 229, 0.08);
+}
+
+.input-widget-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.625rem;
+}
+
+.input-widget-header label {
+  margin-bottom: 0;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.unit-badge {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-primary);
+  background: rgba(79, 70, 229, 0.1);
+  padding: 0.125rem 0.5rem;
+  border-radius: var(--radius-full);
+}
+
+.input-with-unit {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.625rem;
+}
+
+.number-input {
+  flex: 1;
+}
+
+.input-unit {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+</style>

--- a/src/services/storageServices.js
+++ b/src/services/storageServices.js
@@ -1,38 +1,47 @@
 // src/services/storageService.js
-export function saveCalculatorValues(values) {
-    localStorage.setItem('mortgageCalculator', JSON.stringify(values));
+export function saveCalculatorValues(values, currency = 'SEK') {
+  localStorage.setItem('mortgageCalculator', JSON.stringify({ values, currency }));
+}
+
+export function loadCalculatorValues() {
+  const saved = localStorage.getItem('mortgageCalculator');
+  if (!saved) return null;
+
+  const parsed = JSON.parse(saved);
+
+  // Backward compatibility: old saves stored values directly
+  if (parsed.originalLoanAmount !== undefined) {
+    return { values: parsed, currency: 'SEK' };
   }
-  
-  export function loadCalculatorValues() {
-    const saved = localStorage.getItem('mortgageCalculator');
-    return saved ? JSON.parse(saved) : null;
-  }
-  
-  export function getSavedCalculations() {
-    const saved = localStorage.getItem('savedCalculations');
-    return saved ? JSON.parse(saved) : [];
-  }
-  
-  export function saveCalculation(calculation) {
-    const savedCalculations = getSavedCalculations();
-    savedCalculations.push(calculation);
-    localStorage.setItem('savedCalculations', JSON.stringify(savedCalculations));
-    return calculation;
-  }
-  
-  export function deleteCalculation(id) {
-    const savedCalculations = getSavedCalculations();
-    const updated = savedCalculations.filter(calc => calc.id !== id);
-    localStorage.setItem('savedCalculations', JSON.stringify(updated));
-  }
-  
-  export function updateCalculation(updatedCalculation) {
-    const savedCalculations = getSavedCalculations();
-    const updated = savedCalculations.map(calc => {
-      if (calc.id === updatedCalculation.id) {
-        return updatedCalculation;
-      }
-      return calc;
-    });
-    localStorage.setItem('savedCalculations', JSON.stringify(updated));
-  }
+
+  return parsed;
+}
+
+export function getSavedCalculations() {
+  const saved = localStorage.getItem('savedCalculations');
+  return saved ? JSON.parse(saved) : [];
+}
+
+export function saveCalculation(calculation) {
+  const savedCalculations = getSavedCalculations();
+  savedCalculations.push(calculation);
+  localStorage.setItem('savedCalculations', JSON.stringify(savedCalculations));
+  return calculation;
+}
+
+export function deleteCalculation(id) {
+  const savedCalculations = getSavedCalculations();
+  const updated = savedCalculations.filter(calc => calc.id !== id);
+  localStorage.setItem('savedCalculations', JSON.stringify(updated));
+}
+
+export function updateCalculation(updatedCalculation) {
+  const savedCalculations = getSavedCalculations();
+  const updated = savedCalculations.map(calc => {
+    if (calc.id === updatedCalculation.id) {
+      return updatedCalculation;
+    }
+    return calc;
+  });
+  localStorage.setItem('savedCalculations', JSON.stringify(updated));
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -186,3 +186,149 @@ button {
   color: var(--color-text-subtle);
   line-height: 1.4;
 }
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  margin: 0 0 1rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+
+.section-header::before {
+  content: '';
+  width: 4px;
+  height: 1.125rem;
+  border-radius: 2px;
+  background: linear-gradient(180deg, var(--color-primary) 0%, var(--color-accent) 100%);
+  flex-shrink: 0;
+}
+
+.input-section {
+  margin-bottom: 1.5rem;
+}
+
+.input-section:last-child {
+  margin-bottom: 0;
+}
+
+.input-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.range-input {
+  width: 100%;
+  height: 6px;
+  margin: 0.5rem 0 0;
+  appearance: none;
+  background: var(--color-border);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+}
+
+.range-input::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--color-primary) 0%, #6366f1 100%);
+  border: 2px solid white;
+  box-shadow: 0 2px 6px rgba(79, 70, 229, 0.35);
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.range-input::-webkit-slider-thumb:hover {
+  transform: scale(1.1);
+  box-shadow: 0 3px 10px rgba(79, 70, 229, 0.45);
+}
+
+.range-input::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--color-primary) 0%, #6366f1 100%);
+  border: 2px solid white;
+  box-shadow: 0 2px 6px rgba(79, 70, 229, 0.35);
+  cursor: pointer;
+}
+
+.range-input::-moz-range-track {
+  height: 6px;
+  background: var(--color-border);
+  border-radius: var(--radius-full);
+}
+
+.stat-card {
+  padding: 1rem 1.125rem;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.stat-card:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.stat-card--success {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.12) 0%, rgba(16, 185, 129, 0.04) 100%);
+  border-color: rgba(16, 185, 129, 0.2);
+}
+
+.stat-card--warning {
+  background: linear-gradient(135deg, rgba(245, 158, 11, 0.12) 0%, rgba(245, 158, 11, 0.04) 100%);
+  border-color: rgba(245, 158, 11, 0.2);
+}
+
+.stat-card--primary {
+  background: linear-gradient(135deg, var(--color-primary-soft) 0%, rgba(6, 182, 212, 0.08) 100%);
+  border-color: rgba(79, 70, 229, 0.15);
+}
+
+.stat-card-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.375rem;
+}
+
+.stat-card-value {
+  display: block;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text);
+}
+
+.stat-card-value small {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.currency-note {
+  margin: 0 0 1.25rem;
+  padding: 0.625rem 0.875rem;
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  background: var(--color-surface-muted);
+  border-radius: var(--radius-sm);
+  border-left: 3px solid var(--color-accent);
+}

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,0 +1,20 @@
+export const CURRENCIES = { SEK: 'SEK', EUR: 'EUR' };
+export const EUR_SEK_RATE = 11.5;
+
+export function toDisplayAmount(sekAmount, currency) {
+  if (currency === CURRENCIES.EUR) {
+    return Math.round(sekAmount / EUR_SEK_RATE);
+  }
+  return Math.round(sekAmount);
+}
+
+export function fromDisplayAmount(displayAmount, currency) {
+  if (currency === CURRENCIES.EUR) {
+    return Math.round(displayAmount * EUR_SEK_RATE);
+  }
+  return Math.round(displayAmount);
+}
+
+export function currencySymbol(currency) {
+  return currency;
+}

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,8 +1,16 @@
 // src/utils/formatters.js
-export function formatCurrency(amount) {
-    return new Intl.NumberFormat('sv-SE').format(Math.round(amount));
-  }
-  
-  export function formatDate(dateString) {
-    return new Date(dateString).toLocaleDateString();
-  }
+import { CURRENCIES } from './currency.js';
+
+const LOCALE_BY_CURRENCY = {
+  [CURRENCIES.SEK]: 'sv-SE',
+  [CURRENCIES.EUR]: 'de-DE',
+};
+
+export function formatCurrency(amount, currency = CURRENCIES.SEK) {
+  const locale = LOCALE_BY_CURRENCY[currency] || LOCALE_BY_CURRENCY[CURRENCIES.SEK];
+  return new Intl.NumberFormat(locale).format(Math.round(amount));
+}
+
+export function formatDate(dateString) {
+  return new Date(dateString).toLocaleDateString();
+}

--- a/tests/currency.test.js
+++ b/tests/currency.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CURRENCIES,
+  EUR_SEK_RATE,
+  toDisplayAmount,
+  fromDisplayAmount,
+  currencySymbol,
+} from '../src/utils/currency.js';
+
+describe('currency', () => {
+  it('converts SEK to EUR for display', () => {
+    expect(toDisplayAmount(2300000, CURRENCIES.EUR)).toBe(Math.round(2300000 / EUR_SEK_RATE));
+    expect(toDisplayAmount(2300000, CURRENCIES.SEK)).toBe(2300000);
+  });
+
+  it('converts EUR display amounts back to SEK', () => {
+    const eurAmount = 200000;
+    const sekAmount = fromDisplayAmount(eurAmount, CURRENCIES.EUR);
+    expect(sekAmount).toBe(Math.round(eurAmount * EUR_SEK_RATE));
+  });
+
+  it('round-trips SEK amounts unchanged', () => {
+    const original = 2000000;
+    expect(fromDisplayAmount(toDisplayAmount(original, CURRENCIES.SEK), CURRENCIES.SEK)).toBe(original);
+  });
+
+  it('round-trips EUR display amounts approximately', () => {
+    const original = 2000000;
+    const display = toDisplayAmount(original, CURRENCIES.EUR);
+    const back = fromDisplayAmount(display, CURRENCIES.EUR);
+    expect(back).toBeCloseTo(original, -2);
+  });
+
+  it('returns currency symbol', () => {
+    expect(currencySymbol(CURRENCIES.SEK)).toBe('SEK');
+    expect(currencySymbol(CURRENCIES.EUR)).toBe('EUR');
+  });
+});

--- a/tests/formatters.test.js
+++ b/tests/formatters.test.js
@@ -1,10 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import { formatCurrency, formatDate } from '../src/utils/formatters.js';
+import { CURRENCIES } from '../src/utils/currency.js';
 
 describe('formatters', () => {
   it('formats currency with Swedish locale grouping', () => {
     expect(formatCurrency(2000000)).toMatch(/2[\s\u00a0]?000[\s\u00a0]?000/);
     expect(formatCurrency(7500.4)).toBe('7\u00a0500');
+  });
+
+  it('formats EUR with German locale grouping', () => {
+    expect(formatCurrency(173913, CURRENCIES.EUR)).toMatch(/173[\s\u00a0.]?913/);
   });
 
   it('formats dates as locale strings', () => {

--- a/tests/mortgageCalculator.test.js
+++ b/tests/mortgageCalculator.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { calculateMortgage } from '../src/calculations/mortgageCalculator.js';
 
+// Validates calculateMortgage baseline scenarios and LTV edge cases.
 describe('calculateMortgage', () => {
   const defaultInputs = [
     2_000_000, // originalLoanAmount


### PR DESCRIPTION
## Summary
- Add SEK/EUR currency toggle to Loan Details and Monthly Payment panels with fixed-rate conversion (1 EUR = 11.5 SEK)
- Refresh loan inputs with grouped sections, slider-backed fields, and gradient widget styling
- Refresh results panel with gradient hero and stat cards; amounts stay calculated in SEK internally

## Test plan
- [ ] Toggle SEK ↔ EUR and confirm amounts convert visually without changing underlying calculations
- [ ] Edit a value in EUR mode and verify stored values remain correct in SEK
- [ ] Reload the page and confirm currency preference persists
- [ ] Confirm sliders and number inputs stay in sync for all loan fields
- [ ] Run `npm test` and `npm run build`


Made with [Cursor](https://cursor.com)