### PR TITLE
Add GBP currency toggle alongside SEK and EUR

### DIFF
--- a/scripts/browser-test-gbp.mjs
+++ b/scripts/browser-test-gbp.mjs
@@ -1,0 +1,130 @@
+/**
+ * Browser verification for GBP currency toggle.
+ * Run: node scripts/browser-test-gbp.mjs
+ * Requires dev server at http://localhost:5173 (started automatically if not running).
+ */
+import { chromium } from 'playwright';
+import { spawn } from 'child_process';
+import { mkdir } from 'fs/promises';
+import path from 'path';
+
+const BASE_URL = 'http://localhost:5173';
+const ARTIFACTS_DIR = '/opt/cursor/artifacts/gbp-currency-test';
+
+async function waitForServer(url, timeoutMs = 30000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // retry
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`Server not ready at ${url}`);
+}
+
+async function ensureDevServer() {
+  try {
+    await waitForServer(BASE_URL, 2000);
+    console.log('Dev server already running');
+    return null;
+  } catch {
+    console.log('Starting dev server...');
+    const proc = spawn('npm', ['run', 'dev', '--', '--host', '127.0.0.1', '--port', '5173'], {
+      cwd: '/workspace',
+      stdio: 'pipe',
+      detached: false,
+    });
+    await waitForServer(BASE_URL);
+    return proc;
+  }
+}
+
+async function run() {
+  await mkdir(ARTIFACTS_DIR, { recursive: true });
+
+  const devServer = await ensureDevServer();
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    recordVideo: { dir: ARTIFACTS_DIR, size: { width: 1280, height: 800 } },
+    viewport: { width: 1280, height: 800 },
+  });
+  const page = await context.newPage();
+
+  const results = [];
+
+  try {
+    await page.goto(BASE_URL);
+    await page.waitForSelector('.currency-toggle');
+
+    // Verify all three currency buttons exist
+    for (const code of ['SEK', 'EUR', 'GBP']) {
+      const btn = page.locator('.currency-toggle button', { hasText: code });
+      await btn.waitFor({ state: 'visible' });
+      results.push(`✓ ${code} toggle button visible`);
+    }
+
+    // Capture SEK baseline
+    await page.locator('.currency-toggle button', { hasText: 'SEK' }).click();
+    await page.waitForTimeout(300);
+    const sekLoan = await page.locator('#currentLoanAmount').inputValue();
+    results.push(`✓ SEK loan amount: ${sekLoan}`);
+
+    // Switch to GBP and verify conversion
+    await page.locator('.currency-toggle button', { hasText: 'GBP' }).click();
+    await page.waitForTimeout(300);
+    const gbpLoan = Number(await page.locator('#currentLoanAmount').inputValue());
+    const expectedGbp = Math.round(Number(sekLoan) / 13.2);
+    results.push(`✓ GBP loan amount: ${gbpLoan} (expected ~${expectedGbp})`);
+
+    if (Math.abs(gbpLoan - expectedGbp) > 1) {
+      throw new Error(`GBP conversion mismatch: got ${gbpLoan}, expected ${expectedGbp}`);
+    }
+
+    // Verify GBP formatting in results panel
+    const heroValue = await page.locator('.hero-value').textContent();
+    if (!heroValue.includes('GBP')) {
+      throw new Error(`Results not showing GBP: ${heroValue}`);
+    }
+    results.push(`✓ Results display in GBP: ${heroValue.trim()}`);
+
+    // Verify GBP label on loan inputs
+    const gbpLabel = await page.locator('label[for="currentLoanAmount"]').textContent();
+    if (!gbpLabel.includes('GBP')) {
+      throw new Error(`Input label missing GBP: ${gbpLabel}`);
+    }
+    results.push(`✓ Input labels show GBP`);
+
+    // Switch EUR -> GBP and back to SEK round-trip
+    await page.locator('.currency-toggle button', { hasText: 'EUR' }).click();
+    await page.waitForTimeout(300);
+    const eurLoan = await page.locator('#currentLoanAmount').inputValue();
+    results.push(`✓ EUR loan amount: ${eurLoan}`);
+
+    await page.locator('.currency-toggle button', { hasText: 'SEK' }).click();
+    await page.waitForTimeout(300);
+    const sekRoundTrip = Number(await page.locator('#currentLoanAmount').inputValue());
+    if (Math.abs(sekRoundTrip - Number(sekLoan)) > 100) {
+      throw new Error(`Round-trip SEK mismatch: ${sekRoundTrip} vs ${sekLoan}`);
+    }
+    results.push(`✓ Round-trip back to SEK: ${sekRoundTrip}`);
+
+    await page.screenshot({ path: path.join(ARTIFACTS_DIR, 'gbp-toggle-screenshot.png'), fullPage: true });
+    results.push('✓ Screenshot saved');
+
+    console.log('\nBrowser test results:');
+    results.forEach((r) => console.log(r));
+    console.log('\nAll browser tests passed.');
+  } finally {
+    await context.close();
+    await browser.close();
+    if (devServer) devServer.kill();
+  }
+}
+
+run().catch((err) => {
+  console.error('Browser test failed:', err.message);
+  process.exit(1);
+});

--- a/src/MortgageCalculator.vue
+++ b/src/MortgageCalculator.vue
@@ -166,7 +166,7 @@ export default {
         brfFee: 3500
       },
       currency: 'SEK',
-      currencyOptions: ['SEK', 'EUR'],
+      currencyOptions: ['SEK', 'EUR', 'GBP'],
       results: null,
       activeTab: 'scenarios',
       tabs: [

--- a/src/calculations/paymentScenarios.js
+++ b/src/calculations/paymentScenarios.js
@@ -7,11 +7,11 @@ const MAX_PAYOFF_MONTHS = 99 * 12;
 const PRESET_EXTRAS_SEK = [1000, 2000, 5000];
 
 function getPresetExtra(amountSek, currency) {
-  if (currency === 'EUR') {
-    return Math.round(convertAmount(amountSek, 'SEK', 'EUR'));
+  if (currency === 'SEK') {
+    return amountSek;
   }
 
-  return amountSek;
+  return Math.round(convertAmount(amountSek, 'SEK', currency));
 }
 
 function formatExtraLabel(amount, currency) {

--- a/src/components/ExtraPaymentCalculator.vue
+++ b/src/components/ExtraPaymentCalculator.vue
@@ -12,7 +12,7 @@
         type="number"
         v-model.number="extraPayment"
         min="0"
-        :step="currency === 'EUR' ? 10 : 100"
+        :step="currency === 'SEK' ? 100 : 10"
       >
     </div>
 

--- a/src/components/PercentageCalculator.vue
+++ b/src/components/PercentageCalculator.vue
@@ -180,7 +180,7 @@ export default {
   },
   computed: {
     amountStep() {
-      return this.currency === 'EUR' ? 1000 : 10000;
+      return this.currency === 'SEK' ? 10000 : 1000;
     },
     loanToValuePercentage() {
       return (this.values.currentLoanAmount / this.values.originalLoanAmount) * 100;

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,9 +1,17 @@
 export const CURRENCIES = {
   SEK: { code: 'SEK', locale: 'sv-SE', symbol: 'SEK' },
   EUR: { code: 'EUR', locale: 'de-DE', symbol: 'EUR' },
+  GBP: { code: 'GBP', locale: 'en-GB', symbol: 'GBP' },
 };
 
 export const EUR_SEK_RATE = 11.5; // 1 EUR = 11.5 SEK
+export const GBP_SEK_RATE = 13.2; // 1 GBP = 13.2 SEK
+
+const RATES_TO_SEK = {
+  SEK: 1,
+  EUR: EUR_SEK_RATE,
+  GBP: GBP_SEK_RATE,
+};
 
 const MONETARY_FIELDS = [
   'originalLoanAmount',
@@ -22,22 +30,11 @@ export function convertAmount(amount, from, to) {
     return amount;
   }
 
-  if (from === 'SEK' && to === 'EUR') {
-    return amount / EUR_SEK_RATE;
-  }
-
-  if (from === 'EUR' && to === 'SEK') {
-    return amount * EUR_SEK_RATE;
-  }
-
-  return amount;
+  const amountInSek = amount * RATES_TO_SEK[from];
+  return amountInSek / RATES_TO_SEK[to];
 }
 
 export function roundMonetaryAmount(amount, currency = 'SEK') {
-  if (currency === 'EUR') {
-    return Math.round(amount);
-  }
-
   return Math.round(amount);
 }
 

--- a/tests/currency.test.js
+++ b/tests/currency.test.js
@@ -3,12 +3,15 @@ import {
   convertAmount,
   convertValuesCurrency,
   EUR_SEK_RATE,
+  GBP_SEK_RATE,
   getCurrencyConfig,
 } from '../src/utils/currency.js';
 
 describe('currency utilities', () => {
   it('returns currency config with fallback to SEK', () => {
     expect(getCurrencyConfig('EUR').code).toBe('EUR');
+    expect(getCurrencyConfig('GBP').code).toBe('GBP');
+    expect(getCurrencyConfig('GBP').locale).toBe('en-GB');
     expect(getCurrencyConfig('UNKNOWN').code).toBe('SEK');
   });
 
@@ -21,15 +24,35 @@ describe('currency utilities', () => {
     expect(convertAmount(1000, 'EUR', 'SEK')).toBe(11500);
   });
 
+  it('converts SEK to GBP using fixed rate', () => {
+    expect(convertAmount(13200, 'SEK', 'GBP')).toBeCloseTo(1000, 5);
+    expect(convertAmount(2000000, 'SEK', 'GBP')).toBeCloseTo(2000000 / GBP_SEK_RATE, 5);
+  });
+
+  it('converts GBP to SEK using fixed rate', () => {
+    expect(convertAmount(1000, 'GBP', 'SEK')).toBe(13200);
+  });
+
+  it('converts EUR to GBP via SEK hub', () => {
+    const eurAmount = 1000;
+    const inGbp = convertAmount(eurAmount, 'EUR', 'GBP');
+    expect(inGbp).toBeCloseTo((eurAmount * EUR_SEK_RATE) / GBP_SEK_RATE, 5);
+  });
+
   it('round-trips amounts between currencies', () => {
     const original = 2_000_000;
     const inEur = convertAmount(original, 'SEK', 'EUR');
     const backToSek = convertAmount(inEur, 'EUR', 'SEK');
     expect(backToSek).toBeCloseTo(original, 5);
+
+    const inGbp = convertAmount(original, 'SEK', 'GBP');
+    const backFromGbp = convertAmount(inGbp, 'GBP', 'SEK');
+    expect(backFromGbp).toBeCloseTo(original, 5);
   });
 
   it('returns same amount when currencies match', () => {
     expect(convertAmount(7500, 'SEK', 'SEK')).toBe(7500);
+    expect(convertAmount(7500, 'GBP', 'GBP')).toBe(7500);
   });
 
   it('converts all monetary value fields', () => {
@@ -43,14 +66,15 @@ describe('currency utilities', () => {
       brfFee: 3500,
     };
 
-    const converted = convertValuesCurrency(values, 'SEK', 'EUR');
+    const convertedEur = convertValuesCurrency(values, 'SEK', 'EUR');
+    expect(convertedEur.originalLoanAmount).toBe(Math.round(2000000 / EUR_SEK_RATE));
+    expect(convertedEur.interestRate).toBe(3.5);
 
-    expect(converted.originalLoanAmount).toBe(Math.round(2000000 / EUR_SEK_RATE));
-    expect(converted.currentLoanAmount).toBe(Math.round(2000000 / EUR_SEK_RATE));
-    expect(converted.propertyValue).toBe(Math.round(3000000 / EUR_SEK_RATE));
-    expect(converted.annualIncome).toBe(Math.round(500000 / EUR_SEK_RATE));
-    expect(converted.brfFee).toBe(Math.round(3500 / EUR_SEK_RATE));
-    expect(converted.interestRate).toBe(3.5);
-    expect(converted.loanTermYears).toBe(30);
+    const convertedGbp = convertValuesCurrency(values, 'SEK', 'GBP');
+    expect(convertedGbp.originalLoanAmount).toBe(Math.round(2000000 / GBP_SEK_RATE));
+    expect(convertedGbp.propertyValue).toBe(Math.round(3000000 / GBP_SEK_RATE));
+    expect(convertedGbp.brfFee).toBe(Math.round(3500 / GBP_SEK_RATE));
+    expect(convertedGbp.interestRate).toBe(3.5);
+    expect(convertedGbp.loanTermYears).toBe(30);
   });
 });

--- a/tests/formatters.test.js
+++ b/tests/formatters.test.js
@@ -12,9 +12,15 @@ describe('formatters', () => {
     expect(formatCurrency(7500.4, 'EUR')).toBe('7.500');
   });
 
+  it('formats GBP currency with British locale grouping', () => {
+    expect(formatCurrency(100000, 'GBP')).toMatch(/100[,]?000/);
+    expect(formatCurrency(7500.4, 'GBP')).toBe('7,500');
+  });
+
   it('formats money with currency code suffix', () => {
     expect(formatMoney(7500, 'SEK')).toBe('7\u00a0500 SEK');
     expect(formatMoney(7500, 'EUR')).toBe('7.500 EUR');
+    expect(formatMoney(7500, 'GBP')).toBe('7,500 GBP');
   });
 
   it('formats dates as locale strings', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **GBP** as a third currency option in the header toggle, alongside SEK and EUR.

- GBP uses `en-GB` locale formatting (e.g. `7,500 GBP`)
- Fixed exchange rate: **1 GBP = 13.2 SEK** (same fixed-rate approach as EUR)
- Conversion refactored to use **SEK as hub**, so all pairs work (SEK ↔ EUR ↔ GBP)
- Preset payment scenarios and input step sizes updated for GBP scale
- Unit tests added for GBP conversion and formatting

## Browser verification

Tested with Playwright (`scripts/browser-test-gbp.mjs`):

- All three toggle buttons (SEK / EUR / GBP) render correctly
- Switching SEK → GBP converts loan amounts (2,000,000 SEK → 151,515 GBP)
- Results panel and input labels update to show GBP
- Round-trip SEK → GBP → EUR → SEK preserves values

[GBP currency toggle screenshot](https://cursor.com/agents/bc-2777e1e5-bcf2-48fe-95a1-9601cc6f777f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgbp-currency-test%2Fgbp-toggle-screenshot.png)

[page@2c7f8379c55c29c6090661e67790de07.webm](https://cursor.com/agents/bc-2777e1e5-bcf2-48fe-95a1-9601cc6f777f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgbp-currency-test%2Fpage%402c7f8379c55c29c6090661e67790de07.webm)

## Test plan

- [x] `npm test` — 32 tests pass (9 currency, 5 formatters)
- [x] `npm run build` — production build succeeds
- [x] Browser test script — GBP toggle, conversion, and round-trip verified

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2777e1e5-bcf2-48fe-95a1-9601cc6f777f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2777e1e5-bcf2-48fe-95a1-9601cc6f777f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

