### PR TITLE
Add GBP currency option to global currency toggle

### DIFF
--- a/scripts/record-gbp-demo.mjs
+++ b/scripts/record-gbp-demo.mjs
@@ -1,0 +1,86 @@
+import { chromium } from 'playwright';
+import { mkdirSync, renameSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const artifactsDir = '/opt/cursor/artifacts';
+const outputVideo = join(artifactsDir, 'gbp-currency-demo.webm');
+
+mkdirSync(artifactsDir, { recursive: true });
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({
+  recordVideo: {
+    dir: artifactsDir,
+    size: { width: 1280, height: 720 },
+  },
+  viewport: { width: 1280, height: 720 },
+});
+const page = await context.newPage();
+
+await page.goto('http://localhost:3000/', { waitUntil: 'networkidle' });
+await page.waitForSelector('.currency-toggle');
+
+const loanInput = page.locator('#originalLoanAmount');
+const heroValue = page.locator('.hero-value').first();
+
+async function assertContainsCurrency(currency) {
+  await page.waitForFunction(
+    ({ selector, currencyCode }) => {
+      const element = document.querySelector(selector);
+      return element && element.textContent.includes(currencyCode);
+    },
+    { selector: '.hero-value', currencyCode: currency },
+    { timeout: 5000 }
+  );
+}
+
+await page.getByRole('button', { name: 'SEK', exact: true }).click();
+await page.waitForTimeout(400);
+const sekLoan = await loanInput.inputValue();
+if (sekLoan !== '2000000') {
+  throw new Error(`Expected SEK loan amount 2000000, got ${sekLoan}`);
+}
+
+await page.getByRole('button', { name: 'EUR', exact: true }).click();
+await page.waitForTimeout(600);
+await assertContainsCurrency('EUR');
+const eurLoan = Number(await loanInput.inputValue());
+if (Math.abs(eurLoan - Math.round(2_000_000 / 11.5)) > 1) {
+  throw new Error(`Unexpected EUR loan conversion: ${eurLoan}`);
+}
+
+await page.getByRole('button', { name: 'GBP', exact: true }).click();
+await page.waitForTimeout(600);
+await assertContainsCurrency('GBP');
+const gbpLoan = Number(await loanInput.inputValue());
+if (Math.abs(gbpLoan - Math.round(2_000_000 / 13.2)) > 1) {
+  throw new Error(`Unexpected GBP loan conversion: ${gbpLoan}`);
+}
+
+await page.getByRole('button', { name: 'Payment Strategies' }).click();
+await page.waitForTimeout(400);
+await page.getByText('+76 GBP/month').waitFor({ timeout: 5000 });
+
+await page.getByRole('button', { name: 'Amortization Chart' }).click();
+await page.waitForTimeout(800);
+await page.getByRole('button', { name: 'GBP', exact: true }).click();
+await page.waitForTimeout(800);
+
+await page.getByRole('button', { name: 'SEK', exact: true }).click();
+await page.waitForTimeout(500);
+await assertContainsCurrency('SEK');
+
+await page.waitForTimeout(1000);
+
+const video = page.video();
+await context.close();
+await browser.close();
+
+if (!video) {
+  throw new Error('Playwright did not record a video');
+}
+
+const recordedPath = await video.path();
+renameSync(recordedPath, outputVideo);
+
+console.log(`Browser demo passed. Video saved to ${outputVideo}`);

--- a/src/MortgageCalculator.vue
+++ b/src/MortgageCalculator.vue
@@ -166,7 +166,7 @@ export default {
         brfFee: 3500
       },
       currency: 'SEK',
-      currencyOptions: ['SEK', 'EUR'],
+      currencyOptions: ['SEK', 'EUR', 'GBP'],
       results: null,
       activeTab: 'scenarios',
       tabs: [

--- a/src/calculations/paymentScenarios.js
+++ b/src/calculations/paymentScenarios.js
@@ -7,11 +7,11 @@ const MAX_PAYOFF_MONTHS = 99 * 12;
 const PRESET_EXTRAS_SEK = [1000, 2000, 5000];
 
 function getPresetExtra(amountSek, currency) {
-  if (currency === 'EUR') {
-    return Math.round(convertAmount(amountSek, 'SEK', 'EUR'));
+  if (currency === 'SEK') {
+    return amountSek;
   }
 
-  return amountSek;
+  return Math.round(convertAmount(amountSek, 'SEK', currency));
 }
 
 function formatExtraLabel(amount, currency) {

--- a/src/components/ExtraPaymentCalculator.vue
+++ b/src/components/ExtraPaymentCalculator.vue
@@ -12,7 +12,7 @@
         type="number"
         v-model.number="extraPayment"
         min="0"
-        :step="currency === 'EUR' ? 10 : 100"
+        :step="monetaryInputStep"
       >
     </div>
 
@@ -58,6 +58,7 @@
 
 <script>
 import { calculateCustomExtraPayment } from '../calculations/paymentScenarios';
+import { getMonetaryInputStep } from '../utils/currency';
 import { formatMoney, formatPayoffDate } from '../utils/formatters';
 
 export default {
@@ -100,6 +101,9 @@ export default {
       }
 
       return formatPayoffDate(this.customResult.payoffMonths, this.currency);
+    },
+    monetaryInputStep() {
+      return getMonetaryInputStep(this.currency);
     }
   },
   methods: {

--- a/src/components/PercentageCalculator.vue
+++ b/src/components/PercentageCalculator.vue
@@ -128,6 +128,7 @@
 
 <script>
 import { calculateTimeToPayoff } from '../calculations/timeToPayoff';
+import { getLoanAmountStep } from '../utils/currency';
 import { formatMoney } from '../utils/formatters';
 import { AMORTIZATION_RULES } from '../utils/constants';
 
@@ -180,7 +181,7 @@ export default {
   },
   computed: {
     amountStep() {
-      return this.currency === 'EUR' ? 1000 : 10000;
+      return getLoanAmountStep(this.currency);
     },
     loanToValuePercentage() {
       return (this.values.currentLoanAmount / this.values.originalLoanAmount) * 100;

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,9 +1,16 @@
 export const CURRENCIES = {
   SEK: { code: 'SEK', locale: 'sv-SE', symbol: 'SEK' },
   EUR: { code: 'EUR', locale: 'de-DE', symbol: 'EUR' },
+  GBP: { code: 'GBP', locale: 'en-GB', symbol: 'GBP' },
 };
 
 export const EUR_SEK_RATE = 11.5; // 1 EUR = 11.5 SEK
+export const GBP_SEK_RATE = 13.2; // 1 GBP = 13.2 SEK
+
+const RATES_TO_SEK = {
+  EUR: EUR_SEK_RATE,
+  GBP: GBP_SEK_RATE,
+};
 
 const MONETARY_FIELDS = [
   'originalLoanAmount',
@@ -17,27 +24,31 @@ export function getCurrencyConfig(currency = 'SEK') {
   return CURRENCIES[currency] || CURRENCIES.SEK;
 }
 
+function toSek(amount, currency) {
+  if (currency === 'SEK') {
+    return amount;
+  }
+
+  return amount * RATES_TO_SEK[currency];
+}
+
+function fromSek(amountSek, currency) {
+  if (currency === 'SEK') {
+    return amountSek;
+  }
+
+  return amountSek / RATES_TO_SEK[currency];
+}
+
 export function convertAmount(amount, from, to) {
   if (from === to) {
     return amount;
   }
 
-  if (from === 'SEK' && to === 'EUR') {
-    return amount / EUR_SEK_RATE;
-  }
-
-  if (from === 'EUR' && to === 'SEK') {
-    return amount * EUR_SEK_RATE;
-  }
-
-  return amount;
+  return fromSek(toSek(amount, from), to);
 }
 
-export function roundMonetaryAmount(amount, currency = 'SEK') {
-  if (currency === 'EUR') {
-    return Math.round(amount);
-  }
-
+export function roundMonetaryAmount(amount) {
   return Math.round(amount);
 }
 
@@ -46,9 +57,17 @@ export function convertValuesCurrency(values, from, to) {
 
   for (const field of MONETARY_FIELDS) {
     if (converted[field] != null) {
-      converted[field] = roundMonetaryAmount(convertAmount(converted[field], from, to), to);
+      converted[field] = roundMonetaryAmount(convertAmount(converted[field], from, to));
     }
   }
 
   return converted;
+}
+
+export function getMonetaryInputStep(currency = 'SEK') {
+  return currency === 'SEK' ? 100 : 10;
+}
+
+export function getLoanAmountStep(currency = 'SEK') {
+  return currency === 'SEK' ? 10000 : 1000;
 }

--- a/tests/currency.test.js
+++ b/tests/currency.test.js
@@ -3,12 +3,16 @@ import {
   convertAmount,
   convertValuesCurrency,
   EUR_SEK_RATE,
+  GBP_SEK_RATE,
   getCurrencyConfig,
+  getLoanAmountStep,
+  getMonetaryInputStep,
 } from '../src/utils/currency.js';
 
 describe('currency utilities', () => {
   it('returns currency config with fallback to SEK', () => {
     expect(getCurrencyConfig('EUR').code).toBe('EUR');
+    expect(getCurrencyConfig('GBP').code).toBe('GBP');
     expect(getCurrencyConfig('UNKNOWN').code).toBe('SEK');
   });
 
@@ -19,6 +23,22 @@ describe('currency utilities', () => {
 
   it('converts EUR to SEK using fixed rate', () => {
     expect(convertAmount(1000, 'EUR', 'SEK')).toBe(11500);
+  });
+
+  it('converts SEK to GBP using fixed rate', () => {
+    expect(convertAmount(13200, 'SEK', 'GBP')).toBeCloseTo(1000, 5);
+    expect(convertAmount(2000000, 'SEK', 'GBP')).toBeCloseTo(2000000 / GBP_SEK_RATE, 5);
+  });
+
+  it('converts GBP to SEK using fixed rate', () => {
+    expect(convertAmount(1000, 'GBP', 'SEK')).toBe(13200);
+  });
+
+  it('converts between EUR and GBP via SEK', () => {
+    const amountEur = 1000;
+    const amountGbp = convertAmount(amountEur, 'EUR', 'GBP');
+    const backToEur = convertAmount(amountGbp, 'GBP', 'EUR');
+    expect(backToEur).toBeCloseTo(amountEur, 5);
   });
 
   it('round-trips amounts between currencies', () => {
@@ -43,14 +63,22 @@ describe('currency utilities', () => {
       brfFee: 3500,
     };
 
-    const converted = convertValuesCurrency(values, 'SEK', 'EUR');
+    const convertedToEur = convertValuesCurrency(values, 'SEK', 'EUR');
+    expect(convertedToEur.originalLoanAmount).toBe(Math.round(2000000 / EUR_SEK_RATE));
+    expect(convertedToEur.interestRate).toBe(3.5);
 
-    expect(converted.originalLoanAmount).toBe(Math.round(2000000 / EUR_SEK_RATE));
-    expect(converted.currentLoanAmount).toBe(Math.round(2000000 / EUR_SEK_RATE));
-    expect(converted.propertyValue).toBe(Math.round(3000000 / EUR_SEK_RATE));
-    expect(converted.annualIncome).toBe(Math.round(500000 / EUR_SEK_RATE));
-    expect(converted.brfFee).toBe(Math.round(3500 / EUR_SEK_RATE));
-    expect(converted.interestRate).toBe(3.5);
-    expect(converted.loanTermYears).toBe(30);
+    const convertedToGbp = convertValuesCurrency(values, 'SEK', 'GBP');
+    expect(convertedToGbp.originalLoanAmount).toBe(Math.round(2000000 / GBP_SEK_RATE));
+    expect(convertedToGbp.brfFee).toBe(Math.round(3500 / GBP_SEK_RATE));
+    expect(convertedToGbp.interestRate).toBe(3.5);
+    expect(convertedToGbp.loanTermYears).toBe(30);
+  });
+
+  it('returns input steps based on currency scale', () => {
+    expect(getMonetaryInputStep('SEK')).toBe(100);
+    expect(getMonetaryInputStep('EUR')).toBe(10);
+    expect(getMonetaryInputStep('GBP')).toBe(10);
+    expect(getLoanAmountStep('SEK')).toBe(10000);
+    expect(getLoanAmountStep('GBP')).toBe(1000);
   });
 });

--- a/tests/formatters.test.js
+++ b/tests/formatters.test.js
@@ -12,9 +12,15 @@ describe('formatters', () => {
     expect(formatCurrency(7500.4, 'EUR')).toBe('7.500');
   });
 
+  it('formats GBP currency with UK locale grouping', () => {
+    expect(formatCurrency(100000, 'GBP')).toMatch(/100,000/);
+    expect(formatCurrency(7500.4, 'GBP')).toBe('7,500');
+  });
+
   it('formats money with currency code suffix', () => {
     expect(formatMoney(7500, 'SEK')).toBe('7\u00a0500 SEK');
     expect(formatMoney(7500, 'EUR')).toBe('7.500 EUR');
+    expect(formatMoney(7500, 'GBP')).toBe('7,500 GBP');
   });
 
   it('formats dates as locale strings', () => {

--- a/tests/paymentScenarios.test.js
+++ b/tests/paymentScenarios.test.js
@@ -29,6 +29,16 @@ describe('calculateExtraPaymentScenarios', () => {
     expect(scenarios[2].label).toBe('+435 EUR/month');
   });
 
+  it('returns GBP labels when currency is GBP', () => {
+    const gbpLoan = Math.round(currentLoan / 13.2);
+    const gbpBasePayment = Math.round(baseMonthlyPayment / 13.2);
+    const scenarios = calculateExtraPaymentScenarios(gbpLoan, gbpBasePayment, interestRate, 'GBP');
+
+    expect(scenarios[0].label).toBe('+76 GBP/month');
+    expect(scenarios[1].label).toBe('+152 GBP/month');
+    expect(scenarios[2].label).toBe('+379 GBP/month');
+  });
+
   it('reduces payoff time for fixed extra-payment increments', () => {
     const scenarios = calculateExtraPaymentScenarios(currentLoan, baseMonthlyPayment, interestRate);
     const fixedIncrements = scenarios.slice(0, 3);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **GBP** as a third currency option alongside SEK and EUR in the header toggle. Switching currencies converts all monetary inputs and outputs using a fixed rate of **1 GBP = 13.2 SEK** (consistent with the existing fixed-rate approach for EUR).

## Changes

- Extended `src/utils/currency.js` with GBP config (`en-GB` locale) and refactored conversion to route all currency pairs through SEK
- Added shared helpers `getMonetaryInputStep()` and `getLoanAmountStep()` for non-SEK input granularity
- Updated preset extra-payment scenario labels and all display components to support GBP
- Added unit tests for GBP conversion, formatting, and scenario labels
- Added `scripts/record-gbp-demo.mjs` — Playwright script that verifies SEK → EUR → GBP toggling in the browser

## Testing

- [x] `npm test` — 34 tests passing
- [x] `npm run build` — production build succeeds
- [x] Browser verification via Playwright — toggles SEK/EUR/GBP, checks converted loan amounts, GBP preset labels, and chart tab

### Browser demo recording

[gbp-currency-demo.webm](https://cursor.com/agents/bc-9fa67dca-d1f6-4e95-b546-8d4c676e0f13/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgbp-currency-demo.webm)

The recording shows:
1. Starting in SEK (2,000,000 loan)
2. Switching to EUR (~174,000)
3. Switching to GBP (~152,000)
4. Payment Strategies tab with `+76 GBP/month` preset labels
5. Amortization Chart tab in GBP
6. Switching back to SEK

## Notes

Exchange rates used (fixed, for illustration):
- 1 EUR = 11.5 SEK
- 1 GBP = 13.2 SEK


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fa67dca-d1f6-4e95-b546-8d4c676e0f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fa67dca-d1f6-4e95-b546-8d4c676e0f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

