### PR TITLE
Add GBP currency support with SEK/GBP toggle

### DIFF
--- a/src/MortgageCalculator.vue
+++ b/src/MortgageCalculator.vue
@@ -166,7 +166,7 @@ export default {
         brfFee: 3500
       },
       currency: 'SEK',
-      currencyOptions: ['SEK', 'EUR'],
+      currencyOptions: ['SEK', 'GBP'],
       results: null,
       activeTab: 'scenarios',
       tabs: [

--- a/src/calculations/paymentScenarios.js
+++ b/src/calculations/paymentScenarios.js
@@ -7,11 +7,11 @@ const MAX_PAYOFF_MONTHS = 99 * 12;
 const PRESET_EXTRAS_SEK = [1000, 2000, 5000];
 
 function getPresetExtra(amountSek, currency) {
-  if (currency === 'EUR') {
-    return Math.round(convertAmount(amountSek, 'SEK', 'EUR'));
+  if (currency === 'SEK') {
+    return amountSek;
   }
 
-  return amountSek;
+  return Math.round(convertAmount(amountSek, 'SEK', currency));
 }
 
 function formatExtraLabel(amount, currency) {

--- a/src/components/ExtraPaymentCalculator.vue
+++ b/src/components/ExtraPaymentCalculator.vue
@@ -12,7 +12,7 @@
         type="number"
         v-model.number="extraPayment"
         min="0"
-        :step="currency === 'EUR' ? 10 : 100"
+        :step="usesCompactInputSteps(currency) ? 10 : 100"
       >
     </div>
 
@@ -59,6 +59,7 @@
 <script>
 import { calculateCustomExtraPayment } from '../calculations/paymentScenarios';
 import { formatMoney, formatPayoffDate } from '../utils/formatters';
+import { usesCompactInputSteps } from '../utils/currency';
 
 export default {
   name: 'ExtraPaymentCalculator',
@@ -104,6 +105,7 @@ export default {
   },
   methods: {
     formatMoney,
+    usesCompactInputSteps,
     formatTimeSaved(months) {
       const absoluteMonths = Math.abs(months);
       const years = Math.floor(absoluteMonths / 12);

--- a/src/components/PercentageCalculator.vue
+++ b/src/components/PercentageCalculator.vue
@@ -129,6 +129,7 @@
 <script>
 import { calculateTimeToPayoff } from '../calculations/timeToPayoff';
 import { formatMoney } from '../utils/formatters';
+import { usesCompactInputSteps } from '../utils/currency';
 import { AMORTIZATION_RULES } from '../utils/constants';
 
 export default {
@@ -180,7 +181,7 @@ export default {
   },
   computed: {
     amountStep() {
-      return this.currency === 'EUR' ? 1000 : 10000;
+      return usesCompactInputSteps(this.currency) ? 1000 : 10000;
     },
     loanToValuePercentage() {
       return (this.values.currentLoanAmount / this.values.originalLoanAmount) * 100;

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,9 +1,17 @@
 export const CURRENCIES = {
   SEK: { code: 'SEK', locale: 'sv-SE', symbol: 'SEK' },
   EUR: { code: 'EUR', locale: 'de-DE', symbol: 'EUR' },
+  GBP: { code: 'GBP', locale: 'en-GB', symbol: 'GBP' },
 };
 
 export const EUR_SEK_RATE = 11.5; // 1 EUR = 11.5 SEK
+export const GBP_SEK_RATE = 13.5; // 1 GBP = 13.5 SEK
+
+const RATES_TO_SEK = {
+  SEK: 1,
+  EUR: EUR_SEK_RATE,
+  GBP: GBP_SEK_RATE,
+};
 
 const MONETARY_FIELDS = [
   'originalLoanAmount',
@@ -17,27 +25,23 @@ export function getCurrencyConfig(currency = 'SEK') {
   return CURRENCIES[currency] || CURRENCIES.SEK;
 }
 
+export function usesCompactInputSteps(currency = 'SEK') {
+  return currency !== 'SEK';
+}
+
 export function convertAmount(amount, from, to) {
   if (from === to) {
     return amount;
   }
 
-  if (from === 'SEK' && to === 'EUR') {
-    return amount / EUR_SEK_RATE;
-  }
+  const fromRate = RATES_TO_SEK[from] ?? 1;
+  const toRate = RATES_TO_SEK[to] ?? 1;
+  const amountInSek = from === 'SEK' ? amount : amount * fromRate;
 
-  if (from === 'EUR' && to === 'SEK') {
-    return amount * EUR_SEK_RATE;
-  }
-
-  return amount;
+  return to === 'SEK' ? amountInSek : amountInSek / toRate;
 }
 
 export function roundMonetaryAmount(amount, currency = 'SEK') {
-  if (currency === 'EUR') {
-    return Math.round(amount);
-  }
-
   return Math.round(amount);
 }
 

--- a/tests/currency.test.js
+++ b/tests/currency.test.js
@@ -3,12 +3,14 @@ import {
   convertAmount,
   convertValuesCurrency,
   EUR_SEK_RATE,
+  GBP_SEK_RATE,
   getCurrencyConfig,
 } from '../src/utils/currency.js';
 
 describe('currency utilities', () => {
   it('returns currency config with fallback to SEK', () => {
     expect(getCurrencyConfig('EUR').code).toBe('EUR');
+    expect(getCurrencyConfig('GBP').code).toBe('GBP');
     expect(getCurrencyConfig('UNKNOWN').code).toBe('SEK');
   });
 
@@ -21,10 +23,26 @@ describe('currency utilities', () => {
     expect(convertAmount(1000, 'EUR', 'SEK')).toBe(11500);
   });
 
+  it('converts SEK to GBP using fixed rate', () => {
+    expect(convertAmount(13500, 'SEK', 'GBP')).toBeCloseTo(1000, 5);
+    expect(convertAmount(2000000, 'SEK', 'GBP')).toBeCloseTo(2000000 / GBP_SEK_RATE, 5);
+  });
+
+  it('converts GBP to SEK using fixed rate', () => {
+    expect(convertAmount(1000, 'GBP', 'SEK')).toBe(13500);
+  });
+
+  it('converts between EUR and GBP via SEK', () => {
+    const amount = 1000;
+    const inGbp = convertAmount(amount, 'EUR', 'GBP');
+    const backToEur = convertAmount(inGbp, 'GBP', 'EUR');
+    expect(backToEur).toBeCloseTo(amount, 5);
+  });
+
   it('round-trips amounts between currencies', () => {
     const original = 2_000_000;
-    const inEur = convertAmount(original, 'SEK', 'EUR');
-    const backToSek = convertAmount(inEur, 'EUR', 'SEK');
+    const inGbp = convertAmount(original, 'SEK', 'GBP');
+    const backToSek = convertAmount(inGbp, 'GBP', 'SEK');
     expect(backToSek).toBeCloseTo(original, 5);
   });
 
@@ -32,7 +50,29 @@ describe('currency utilities', () => {
     expect(convertAmount(7500, 'SEK', 'SEK')).toBe(7500);
   });
 
-  it('converts all monetary value fields', () => {
+  it('converts all monetary value fields to GBP', () => {
+    const values = {
+      originalLoanAmount: 2000000,
+      currentLoanAmount: 2000000,
+      propertyValue: 3000000,
+      annualIncome: 500000,
+      interestRate: 3.5,
+      loanTermYears: 30,
+      brfFee: 3500,
+    };
+
+    const converted = convertValuesCurrency(values, 'SEK', 'GBP');
+
+    expect(converted.originalLoanAmount).toBe(Math.round(2000000 / GBP_SEK_RATE));
+    expect(converted.currentLoanAmount).toBe(Math.round(2000000 / GBP_SEK_RATE));
+    expect(converted.propertyValue).toBe(Math.round(3000000 / GBP_SEK_RATE));
+    expect(converted.annualIncome).toBe(Math.round(500000 / GBP_SEK_RATE));
+    expect(converted.brfFee).toBe(Math.round(3500 / GBP_SEK_RATE));
+    expect(converted.interestRate).toBe(3.5);
+    expect(converted.loanTermYears).toBe(30);
+  });
+
+  it('converts all monetary value fields to EUR', () => {
     const values = {
       originalLoanAmount: 2000000,
       currentLoanAmount: 2000000,

--- a/tests/formatters.test.js
+++ b/tests/formatters.test.js
@@ -12,9 +12,15 @@ describe('formatters', () => {
     expect(formatCurrency(7500.4, 'EUR')).toBe('7.500');
   });
 
+  it('formats GBP currency with British locale grouping', () => {
+    expect(formatCurrency(100000, 'GBP')).toMatch(/100,?000/);
+    expect(formatCurrency(7500.4, 'GBP')).toBe('7,500');
+  });
+
   it('formats money with currency code suffix', () => {
     expect(formatMoney(7500, 'SEK')).toBe('7\u00a0500 SEK');
     expect(formatMoney(7500, 'EUR')).toBe('7.500 EUR');
+    expect(formatMoney(7500, 'GBP')).toBe('7,500 GBP');
   });
 
   it('formats dates as locale strings', () => {

--- a/tests/paymentScenarios.test.js
+++ b/tests/paymentScenarios.test.js
@@ -19,6 +19,16 @@ describe('calculateExtraPaymentScenarios', () => {
     ]);
   });
 
+  it('returns GBP labels when currency is GBP', () => {
+    const gbpLoan = Math.round(currentLoan / 13.5);
+    const gbpBasePayment = Math.round(baseMonthlyPayment / 13.5);
+    const scenarios = calculateExtraPaymentScenarios(gbpLoan, gbpBasePayment, interestRate, 'GBP');
+
+    expect(scenarios[0].label).toBe('+74 GBP/month');
+    expect(scenarios[1].label).toBe('+148 GBP/month');
+    expect(scenarios[2].label).toBe('+370 GBP/month');
+  });
+
   it('returns EUR labels when currency is EUR', () => {
     const eurLoan = Math.round(currentLoan / 11.5);
     const eurBasePayment = Math.round(baseMonthlyPayment / 11.5);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds British Pound (GBP) support to the mortgage calculator and updates the header currency toggle to switch between **SEK** and **GBP**.

## Changes

- Added GBP to the currency configuration with `en-GB` locale formatting (e.g. `148,148 GBP`)
- Introduced a fixed GBP/SEK exchange rate (`1 GBP = 13.5 SEK`) and refactored conversion logic to route all currency pairs through SEK
- Replaced the EUR option in the header toggle with GBP; EUR conversion remains available for saved calculations that use it
- Monetary input fields (loan amounts, property value, income, Brf fee) convert automatically when toggling currency
- Updated input step sizes and preset extra-payment scenario labels for GBP
- Added unit tests for GBP conversion, formatting, and payment scenario labels

## Testing

- `npm run ci` — all 34 tests pass
- Browser verification with Playwright:
  - Header toggle shows SEK and GBP
  - Switching to GBP converts and formats all monetary values correctly
  - Payment strategy presets display GBP labels (e.g. `+74 GBP/month`)
  - Switching back to SEK restores values (within expected rounding tolerance)

## Notes

The fixed exchange rate is approximate and intended for calculator convenience, consistent with the existing EUR/SEK approach.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6732fded-4ea4-4cdf-8ce9-14129f4f8872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6732fded-4ea4-4cdf-8ce9-14129f4f8872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

